### PR TITLE
Fix stack overflow check and add tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ impl CHIP8 {
     }
 
     fn call(&mut self, addr: u16) {
-        if self.sp > self.stack.len() {
+        if self.sp >= self.stack.len() {
             panic!("Stack overflow");
         }
 
@@ -81,5 +81,33 @@ impl CHIP8 {
         self.sp -= 1;
         let addr = self.stack[self.sp];
         self.pc = addr as usize;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn call_and_ret_update_stack_and_pc() {
+        let mut chip = CHIP8::new();
+        chip.pc = 0x200;
+        chip.call(0x300);
+
+        assert_eq!(chip.sp, 1);
+        assert_eq!(chip.stack[0], 0x200);
+        assert_eq!(chip.pc, 0x300);
+
+        chip.ret();
+        assert_eq!(chip.sp, 0);
+        assert_eq!(chip.pc, 0x200);
+    }
+
+    #[test]
+    #[should_panic(expected = "Stack overflow")]
+    fn call_panics_on_stack_overflow() {
+        let mut chip = CHIP8::new();
+        chip.sp = chip.stack.len();
+        chip.call(0x200);
     }
 }


### PR DESCRIPTION
## Summary
- avoid indexing beyond the end of the call stack by correcting the overflow check
- add regression tests for CALL/RET logic

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68487ea2cd20833090b8cb0f54b0b7b5